### PR TITLE
fix(nodeport): lets allow the nodeIP to be configured

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,3 @@
+exposer: Route
+watch-current-namespace: true
+

--- a/controller/config.go
+++ b/controller/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	Domain                string `yaml:"domain,omitempty"`
 	Exposer               string `yaml:"exposer"`
 	ApiServer             string `yaml:"apiserver,omitempty"`
+	NodeIP                string `yaml:"node-ip,omitempty"`
 	ConsoleURL            string `yaml:"console-url,omitempty"`
 	AuthorizePath         string `yaml:"authorize-path,omitempty"`
 	ApiServerProtocol     string `yaml:"apiserver-protocol"`

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -3,8 +3,8 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -13,14 +13,14 @@ import (
 	"github.com/pkg/errors"
 
 	"k8s.io/kubernetes/pkg/api"
+	uapi "k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/controller/framework"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
-	uapi "k8s.io/kubernetes/pkg/api/unversioned"
 
 	"github.com/fabric8io/exposecontroller/exposestrategy"
 
@@ -72,7 +72,7 @@ func NewController(
 		}),
 	}
 
-	strategy, err := exposestrategy.New(config.Exposer, config.Domain, kubeClient, restClientConfig, encoder)
+	strategy, err := exposestrategy.New(config.Exposer, config.Domain, config.NodeIP, kubeClient, restClientConfig, encoder)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create new strategy")
 	}

--- a/exposestrategy/auto.go
+++ b/exposestrategy/auto.go
@@ -23,7 +23,7 @@ const (
 	stackpointIPEnvVar = "BALANCER_IP"
 )
 
-func NewAutoStrategy(exposer, domain string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func NewAutoStrategy(exposer, domain, nodeIP string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 
 	exposer, err := getAutoDefaultExposeRule(client)
 	if err != nil {
@@ -40,7 +40,7 @@ func NewAutoStrategy(exposer, domain string, client *client.Client, restClientCo
 		glog.Infof("Using domain: %s", domain)
 	}
 
-	return New(exposer, domain, client, restClientConfig, encoder)
+	return New(exposer, domain, nodeIP, client, restClientConfig, encoder)
 }
 
 func getAutoDefaultExposeRule(c *client.Client) (string, error) {

--- a/exposestrategy/strategy.go
+++ b/exposestrategy/strategy.go
@@ -28,7 +28,7 @@ var (
 	ApiServicePathAnnotationKey = "api.service.kubernetes.io/path"
 )
 
-func New(exposer, domain string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func New(exposer, domain, nodeIP string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 	switch strings.ToLower(exposer) {
 	case "loadbalancer":
 		strategy, err := NewLoadBalancerStrategy(client, encoder)
@@ -37,7 +37,7 @@ func New(exposer, domain string, client *client.Client, restClientConfig *restcl
 		}
 		return strategy, nil
 	case "nodeport":
-		strategy, err := NewNodePortStrategy(client, encoder)
+		strategy, err := NewNodePortStrategy(client, encoder, nodeIP)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create node port expose strategy")
 		}
@@ -60,7 +60,7 @@ func New(exposer, domain string, client *client.Client, restClientConfig *restcl
 		}
 		return strategy, nil
 	case "":
-		strategy, err := NewAutoStrategy(exposer, domain, client, restClientConfig, encoder)
+		strategy, err := NewAutoStrategy(exposer, domain, nodeIP, client, restClientConfig, encoder)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create auto expose strategy")
 		}


### PR DESCRIPTION
this enables us to avoid security issues of being able to list nodes so that folks can specify the nodeIP on startup such as when running in minishift