### PR TITLE
add tls spec for the ingress strategy

### DIFF
--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -97,6 +97,7 @@ func (s *IngressStrategy) Add(svc *api.Service) error {
 		ingress.Spec.Rules = append(ingress.Spec.Rules, rule)
 	}
 
+	ingress.Spec.TLS = []extensions.IngressTLS{}
 	tls := extensions.IngressTLS{
 		Hosts: hostName,
 		SecretName: svc.Name + "-tls",

--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -92,6 +92,12 @@ func (s *IngressStrategy) Add(svc *api.Service) error {
 		ingress.Spec.Rules = append(ingress.Spec.Rules, rule)
 	}
 
+	tls := extensions.IngressTLS{
+		Hosts: hostName,
+		SecretName: svc.Name + "-tls",
+	}
+	ingress.Spec.TLS = append(ingress.Spec.TLS, tls)
+
 	if createIngress {
 		_, err := s.client.Ingress(ingress.Namespace).Create(ingress)
 		if err != nil {

--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -72,6 +72,11 @@ func (s *IngressStrategy) Add(svc *api.Service) error {
 	}
 	ingress.Labels["provider"] = "fabric8"
 
+	if ingress.Annotations == nil {
+		ingress.Annotations = map[string]string{}
+	}
+	ingress.Annotations["kubernetes.io/tls-acme"] = "true"
+
 	ingress.Spec.Rules = []extensions.IngressRule{}
 	for _, port := range svc.Spec.Ports {
 		rule := extensions.IngressRule{


### PR DESCRIPTION
* the tls spec part is generic
* the added annotation will enable kube-lego to handle tls with letsencrypt