### PR TITLE
adds provided annotations to ingress

### DIFF
--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -87,9 +87,9 @@ func (s *IngressStrategy) Add(svc *api.Service) error {
 		tlsSecretName = "tls-" + svc.Name
 	}
 
-	annotationsForIngress := svc.Labels["annotations-for-ingress"]
+	annotationsForIngress := svc.Annotations["fabric8.io/ingress.annotations"]
 	if annotationsForIngress != "" {
-		annotations := strings.Split(annotationsForIngress, ",")
+		annotations := strings.Split(annotationsForIngress, "\n")
 		for _, element := range annotations {
 			annotation := strings.Split(element, ":")
 			key, value := annotation[0], annotation[1]

--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -92,7 +92,7 @@ func (s *IngressStrategy) Add(svc *api.Service) error {
 		annotations := strings.Split(annotationsForIngress, "\n")
 		for _, element := range annotations {
 			annotation := strings.Split(element, ":")
-			key, value := annotation[0], annotation[1]
+			key, value := annotation[0], strings.TrimSpace(annotation[1])
 			ingress.Annotations[key] = value
 		}
 	}

--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -3,6 +3,7 @@ package exposestrategy
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -84,6 +85,16 @@ func (s *IngressStrategy) Add(svc *api.Service) error {
 	if s.tlsAcme {
 		ingress.Annotations["kubernetes.io/tls-acme"] = "true"
 		tlsSecretName = "tls-" + svc.Name
+	}
+
+	annotationsForIngress := svc.Labels["annotations-for-ingress"]
+	if annotationsForIngress != "" {
+		annotations := strings.Split(annotationsForIngress, ",")
+		for _, element := range annotations {
+			annotation := strings.Split(element, ":")
+			key, value := annotation[0], annotation[1]
+			ingress.Annotations[key] = value
+		}
 	}
 
 	ingress.Spec.Rules = []extensions.IngressRule{}


### PR DESCRIPTION
Given a service which has a label that contains comma separated list of annotations which must be added to the ingress which is being created for this particular service; then they must be added by the exposecontroller.

So, if Service has following label:

```
annotations-for-ingress: "ingress.kubernetes.io/force-ssl-redirect: "true"|kubernetes.io/ingress.class: "tools""
```

Then the output Ingress should look like following:

```
  annotations:
    ingress.kubernetes.io/force-ssl-redirect: "true"
    kubernetes.io/ingress.class: "tools"
```