### PR TITLE
Add a oneshot and a daemon mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM scratch
 
-ENTRYPOINT ["/exposecontroller"]
+ENTRYPOINT ["/exposecontroller", "--daemon"]
 
 COPY ./out/exposecontroller-linux-amd64 /exposecontroller

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -544,6 +544,10 @@ func (c *Controller) Stop() {
 	close(c.stopCh)
 }
 
+func (c *Controller) Hasrun() bool {
+	return c.svcController.HasSynced()
+}
+
 func serviceListFunc(c *client.Client, ns string) func(api.ListOptions) (runtime.Object, error) {
 	return func(opts api.ListOptions) (runtime.Object, error) {
 		return c.Services(ns).List(opts)

--- a/exposecontroller.go
+++ b/exposecontroller.go
@@ -36,6 +36,12 @@ var (
 	profiling = flags.Bool("profiling", true, `Enable profiling via web interface host:port/debug/pprof/`)
 
 	daemon = flag.Bool("daemon", false, `Run as daemon mode watching changes as it happens.`)
+
+	domain     = flag.String("domain", "", "Domain to use with your DNS provider (default: .nip.io).")
+	exposer    = flag.String("exposer", "", "Which strategy exposecontroller should use to access applications")
+	apiserver  = flag.String("api-server", "", "API server URL")
+	consoleurl = flag.String("console-server", "", "Console URL")
+	httpb      = flag.Bool("http", false, `Use HTTP`)
 )
 
 func main() {
@@ -60,6 +66,22 @@ func main() {
 	controllerConfig, err := controller.LoadFile(*configFile)
 	if err != nil {
 		glog.Fatalf("%s", err)
+	}
+
+	if *domain != "" {
+		controllerConfig.Domain = *domain
+	}
+	if *exposer != "" {
+		controllerConfig.Exposer = *exposer
+	}
+	if *apiserver != "" {
+		controllerConfig.ApiServer = *apiserver
+	}
+	if *consoleurl != "" {
+		controllerConfig.ConsoleURL = *consoleurl
+	}
+	if *httpb {
+		controllerConfig.HTTP = *httpb
 	}
 
 	//watchNamespaces := api.NamespaceAll


### PR DESCRIPTION
If --daemon is specified, run like before watching for changes
undefinitely.

By default run in a "one shot" mode, which mean just run one time and
exit.

Github Issue #44