### PR TITLE
templatize url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ release
 out/
 _gopath/
 .DS_Store
+/vendor

--- a/controller/config.go
+++ b/controller/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	WatchCurrentNamespace bool   `yaml:"watch-current-namespace"`
 	HTTP                  bool   `yaml:"http"`
 	TLSAcme               bool   `yaml:"tls-acme"`
+	UrlTemplate           string `yaml:"urltemplate,omitempty"`
 	// original is the input from which the config was parsed.
 	original string
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -73,7 +73,7 @@ func NewController(
 		}),
 	}
 
-	strategy, err := exposestrategy.New(config.Exposer, config.Domain, config.NodeIP, config.RouteHost, config.RouteUsePath, config.HTTP, config.TLSAcme, kubeClient, restClientConfig, encoder)
+	strategy, err := exposestrategy.New(config.Exposer, config.Domain, config.UrlTemplate, config.NodeIP, config.RouteHost, config.RouteUsePath, config.HTTP, config.TLSAcme, kubeClient, restClientConfig, encoder)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create new strategy")
 	}

--- a/examples/config-map.yml
+++ b/examples/config-map.yml
@@ -7,6 +7,8 @@ data:
     # exposer: Ingress
     # exposer: Route
     # exposer: NodePort
+    # For ingress; exposers can set the urltemplate to expose
+    # urltemplate: "{{.Service}}.{{.Namespace}}.{{.Domain}}"     
 kind: "ConfigMap"
 metadata:
   labels:

--- a/exposestrategy/auto.go
+++ b/exposestrategy/auto.go
@@ -23,7 +23,7 @@ const (
 	stackpointIPEnvVar = "BALANCER_IP"
 )
 
-func NewAutoStrategy(exposer, domain, nodeIP, routeHost string, routeUsePath, http, tlsAcme bool, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func NewAutoStrategy(exposer, domain, urltemplate string, nodeIP, routeHost string, routeUsePath, http, tlsAcme bool, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 
 	exposer, err := getAutoDefaultExposeRule(client)
 	if err != nil {
@@ -40,7 +40,7 @@ func NewAutoStrategy(exposer, domain, nodeIP, routeHost string, routeUsePath, ht
 		glog.Infof("Using domain: %s", domain)
 	}
 
-	return New(exposer, domain, nodeIP, routeHost, routeUsePath, http, tlsAcme, client, restClientConfig, encoder)
+	return New(exposer, domain, urltemplate, nodeIP, routeHost, routeUsePath, http, tlsAcme, client, restClientConfig, encoder)
 }
 
 func getAutoDefaultExposeRule(c *client.Client) (string, error) {

--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -54,12 +54,12 @@ func NewIngressStrategy(client *client.Client, encoder runtime.Encoder, domain s
 	glog.Infof("Using url template [%s] format [%s]", urltemplate, urlformat)
 
 	return &IngressStrategy{
-		client:  client,
-		encoder: encoder,
-		domain:  domain,
-		http:    http,
-		tlsAcme: tlsAcme,
-		urltemplate: urlformat
+		client:      client,
+		encoder:     encoder,
+		domain:      domain,
+		http:        http,
+		tlsAcme:     tlsAcme,
+		urltemplate: urlformat,
 	}, nil
 }
 
@@ -74,7 +74,7 @@ func (s *IngressStrategy) Add(svc *api.Service) error {
 		}
 	}
 
-	hostName := fmt.Sprintf(s.urltemplate,, appName, svc.Namespace, s.domain)
+	hostName := fmt.Sprintf(s.urltemplate, appName, svc.Namespace, s.domain)
 
 	ingress, err := s.client.Ingress(svc.Namespace).Get(appName)
 	createIngress := false

--- a/exposestrategy/strategy.go
+++ b/exposestrategy/strategy.go
@@ -29,7 +29,7 @@ var (
 	ApiServicePathAnnotationKey = "api.service.kubernetes.io/path"
 )
 
-func New(exposer, domain, nodeIP, routeHost string, routeUsePath, http, tlsAcme bool, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func New(exposer, domain, urltemplate, nodeIP, routeHost string, routeUsePath, http, tlsAcme bool, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 	switch strings.ToLower(exposer) {
 	case "loadbalancer":
 		strategy, err := NewLoadBalancerStrategy(client, encoder)
@@ -44,7 +44,7 @@ func New(exposer, domain, nodeIP, routeHost string, routeUsePath, http, tlsAcme 
 		}
 		return strategy, nil
 	case "ingress":
-		strategy, err := NewIngressStrategy(client, encoder, domain, http, tlsAcme)
+		strategy, err := NewIngressStrategy(client, encoder, domain, http, tlsAcme, urltemplate)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create ingress expose strategy")
 		}

--- a/exposestrategy/strategy.go
+++ b/exposestrategy/strategy.go
@@ -61,7 +61,7 @@ func New(exposer, domain, urltemplate, nodeIP, routeHost string, routeUsePath, h
 		}
 		return strategy, nil
 	case "":
-		strategy, err := NewAutoStrategy(exposer, domain, nodeIP, routeHost, routeUsePath, http, tlsAcme, client, restClientConfig, encoder)
+		strategy, err := NewAutoStrategy(exposer, domain, urltemplate, nodeIP, routeHost, routeUsePath, http, tlsAcme, client, restClientConfig, encoder)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create auto expose strategy")
 		}

--- a/exposestrategy/utils.go
+++ b/exposestrategy/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"strings"
+	"text/template"
 
 	"github.com/pkg/errors"
 
@@ -117,4 +118,27 @@ func typeOfMaster(c *client.Client) (masterType, error) {
 		}
 	}
 	return kubernetes, nil
+}
+
+type urlTemplateParts struct {
+	Service   string
+	Namespace string
+	Domain    string
+}
+
+func getURLFormat(urltemplate string) (string, error) {
+	if urltemplate == "" {
+		urltemplate = "{{.Service}}.{{.Namespace}}.{{.Domain}}"
+	}
+	placeholders := urlTemplateParts{"%[1]s", "%[2]s", "%[3]s"}
+	tmpl, err := template.New("format").Parse(urltemplate)
+	if err != nil {
+		errors.Wrap(err, "Failed to parse UrlTemplate")
+	}
+	var buffer bytes.Buffer
+	err = tmpl.Execute(&buffer, placeholders)
+	if err != nil {
+		errors.Wrap(err, "Failed to execute UrlTemplate")
+	}
+	return buffer.String(), nil
 }


### PR DESCRIPTION
copy of this PR https://github.com/fabric8io/exposecontroller/pull/37 but for ingress's only

The purpose of this PR is to provide a flexible way to change the URL of the generated ingress resources.

The changes allow complete flexibility in generating URLs using the .Service, .Namespace and .Domain placeholders.